### PR TITLE
support for Fujitsu model S13-450P1

### DIFF
--- a/pmbus.cpp
+++ b/pmbus.cpp
@@ -158,7 +158,7 @@ void PMBus::check_model() {
   
   // Model specific setup.
 
-  if (strncmp(&mfr_model[1], "DPS750TB1", 9) == 0) {
+  if (strncmp(&mfr_model[1],"DPS750TB1",9) == 0) {
 
     status_reg[5] = 0;
     status_reg[6] = 0;

--- a/pmbus.cpp
+++ b/pmbus.cpp
@@ -158,10 +158,7 @@ void PMBus::check_model() {
   
   // Model specific setup.
 
-  if (
-    (strncmp(&mfr_model[1], "DPS750TB1", 9) == 0) || 
-    (strncmp(&mfr_model[1], "S13-", 4) == 0)
-    ) {
+  if (strncmp(&mfr_model[1], "DPS750TB1", 9) == 0) {
 
     status_reg[5] = 0;
     status_reg[6] = 0;
@@ -189,6 +186,15 @@ void PMBus::check_model() {
       total_power_on  |= buffer[i];
     }
 
+  } else if (strncmp(&mfr_model[1], "S13-", 4) == 0) {
+
+    status_reg[5] = 0;
+    status_reg[6] = 0;
+
+    temperatures  = 2;
+    fans          = 1;
+    vout_scale   = 1.0 / (float) 0x200;
+    
   } else {
 
     status_reg[7] = 0;    

--- a/pmbus.cpp
+++ b/pmbus.cpp
@@ -158,7 +158,10 @@ void PMBus::check_model() {
   
   // Model specific setup.
 
-  if (strncmp(&mfr_model[1],"DPS750TB1",9) == 0) {
+  if (
+    (strncmp(&mfr_model[1], "DPS750TB1", 9) == 0) || 
+    (strncmp(&mfr_model[1], "S13-", 4) == 0)
+    ) {
 
     status_reg[5] = 0;
     status_reg[6] = 0;


### PR DESCRIPTION
Fujitsu S13-450P1
address pins B17 and B18 to GND
pin A17 to SDA
pin A18 to SCL

tested on ESP8266